### PR TITLE
Add Flutter skeleton

### DIFF
--- a/cam_flutter/bin/server.dart
+++ b/cam_flutter/bin/server.dart
@@ -1,0 +1,84 @@
+import 'dart:async';
+import 'dart:io';
+import 'dart:typed_data';
+import 'package:shelf/shelf.dart';
+import 'package:shelf/shelf_io.dart' as io;
+import 'package:shelf_web_socket/shelf_web_socket.dart';
+
+class CameraServer {
+  final String camIp;
+  final int camPort;
+  final List<int> keepAlivePorts;
+  late RawDatagramSocket _udp;
+  final _clients = <WebSocket>[];
+  bool _running = false;
+
+  CameraServer({
+    required this.camIp,
+    required this.camPort,
+    this.keepAlivePorts = const [8070, 8080],
+  });
+
+  Future<void> start({InternetAddress address = InternetAddress.anyIPv4, int port = 8081}) async {
+    _udp = await RawDatagramSocket.bind(InternetAddress.anyIPv4, 0);
+    _running = true;
+    _keepAliveLoop();
+    _streamLoop();
+    final handler = webSocketHandler((WebSocket ws) {
+      _clients.add(ws);
+      ws.done.whenComplete(() => _clients.remove(ws));
+    });
+    final pipeline = const Pipeline().addMiddleware(logRequests()).addHandler(handler);
+    await io.serve(pipeline, address, port);
+    print('HTTP stream on http://${address.address}:$port');
+  }
+
+  void _keepAliveLoop() {
+    Timer.periodic(const Duration(seconds: 1), (t) {
+      if (!_running) return;
+      for (final port in keepAlivePorts) {
+        final payload = port == 8080 ? [0x42, 0x76] : [0x30, 0x66];
+        _udp.send(Uint8List.fromList(payload), InternetAddress(camIp), port);
+      }
+    });
+  }
+
+  void _streamLoop() {
+    final buffer = BytesBuilder();
+    bool collecting = false;
+    _udp.listen((event) {
+      if (event == RawSocketEvent.read) {
+        final datagram = _udp.receive();
+        if (datagram == null) return;
+        final data = datagram.data;
+        if (data.length < 8) return;
+        final payload = data.sublist(8);
+        if (payload.length >= 2 && payload[0] == 0xff && payload[1] == 0xd8) {
+          buffer.clear();
+          buffer.add(payload);
+          collecting = true;
+        } else if (collecting) {
+          buffer.add(payload);
+        }
+        if (collecting && payload.contains(0xd9)) {
+          final frame = buffer.toBytes();
+          collecting = false;
+          _broadcastFrame(frame);
+        }
+      }
+    });
+  }
+
+  void _broadcastFrame(List<int> jpeg) {
+    for (final ws in _clients) {
+      if (ws.readyState == WebSocket.open) {
+        ws.add(jpeg);
+      }
+    }
+  }
+}
+
+Future<void> main(List<String> args) async {
+  final server = CameraServer(camIp: '192.168.4.153', camPort: 8080);
+  await server.start();
+}

--- a/cam_flutter/lib/main.dart
+++ b/cam_flutter/lib/main.dart
@@ -1,0 +1,50 @@
+import 'dart:convert';
+import 'dart:typed_data';
+import 'package:flutter/material.dart';
+import 'package:web_socket_channel/web_socket_channel.dart';
+
+void main() {
+  runApp(const CamApp());
+}
+
+class CamApp extends StatefulWidget {
+  const CamApp({super.key});
+
+  @override
+  State<CamApp> createState() => _CamAppState();
+}
+
+class _CamAppState extends State<CamApp> {
+  final _channel = WebSocketChannel.connect(Uri.parse('ws://localhost:8081'));
+  Uint8List? _frame;
+
+  @override
+  void initState() {
+    super.initState();
+    _channel.stream.listen((data) {
+      setState(() {
+        _frame = data as Uint8List;
+      });
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      home: Scaffold(
+        appBar: AppBar(title: const Text('Cam Stream')),
+        body: Center(
+          child: _frame == null
+              ? const Text('Waiting for stream...')
+              : Image.memory(_frame!),
+        ),
+      ),
+    );
+  }
+
+  @override
+  void dispose() {
+    _channel.sink.close();
+    super.dispose();
+  }
+}

--- a/cam_flutter/pubspec.yaml
+++ b/cam_flutter/pubspec.yaml
@@ -1,0 +1,13 @@
+name: cam_flutter
+description: Camera streaming server and viewer in Flutter/Dart
+version: 0.1.0
+environment:
+  sdk: ">=3.0.0 <4.0.0"
+dependencies:
+  flutter:
+    sdk: flutter
+  shelf: ^1.4.0
+  shelf_web_socket: ^1.0.1
+  image: ^4.1.3
+  provider: ^6.1.2
+  web_socket_channel: ^2.4.0


### PR DESCRIPTION
## Summary
- add a new `cam_flutter` folder containing a basic Flutter/Dart rewrite
- include a server to receive UDP camera packets and serve frames over a WebSocket
- include a minimal Flutter UI that displays the MJPEG stream
- add pubspec for dependencies

## Testing
- `flutter --version`
- `flutter pub get` *(fails: The current Flutter SDK version is 0.0.0-unknown)*

------
https://chatgpt.com/codex/tasks/task_e_6848288833648326bf7a27bc1f157734