### PR TITLE
Use UDP stream with Provider

### DIFF
--- a/cam_flutter/lib/main.dart
+++ b/cam_flutter/lib/main.dart
@@ -1,50 +1,45 @@
-import 'dart:convert';
+import 'dart:io';
+import 'dart:async';
 import 'dart:typed_data';
 import 'package:flutter/material.dart';
-import 'package:web_socket_channel/web_socket_channel.dart';
+import 'package:provider/provider.dart';
+import 'udp_stream_receiver.dart';
 
 void main() {
   runApp(const CamApp());
 }
 
-class CamApp extends StatefulWidget {
+class CamApp extends StatelessWidget {
   const CamApp({super.key});
 
   @override
-  State<CamApp> createState() => _CamAppState();
-}
-
-class _CamAppState extends State<CamApp> {
-  final _channel = WebSocketChannel.connect(Uri.parse('ws://localhost:8081'));
-  Uint8List? _frame;
-
-  @override
-  void initState() {
-    super.initState();
-    _channel.stream.listen((data) {
-      setState(() {
-        _frame = data as Uint8List;
-      });
-    });
-  }
-
-  @override
   Widget build(BuildContext context) {
-    return MaterialApp(
-      home: Scaffold(
-        appBar: AppBar(title: const Text('Cam Stream')),
-        body: Center(
-          child: _frame == null
-              ? const Text('Waiting for stream...')
-              : Image.memory(_frame!),
+    return ChangeNotifierProvider(
+      create: (_) => UdpStreamReceiver(camIp: '192.168.4.153', camPort: 8080),
+      child: MaterialApp(
+        home: Scaffold(
+          appBar: AppBar(title: const Text('Cam Stream')),
+          body: const Center(child: _CamView()),
         ),
       ),
     );
   }
+}
+
+class _CamView extends StatelessWidget {
+  const _CamView();
 
   @override
-  void dispose() {
-    _channel.sink.close();
-    super.dispose();
+  Widget build(BuildContext context) {
+    final receiver = context.watch<UdpStreamReceiver>();
+    return ValueListenableBuilder<Uint8List?>(
+      valueListenable: receiver.frame,
+      builder: (context, data, _) {
+        if (data == null) {
+          return const Text('Waiting for stream...');
+        }
+        return Image.memory(data);
+      },
+    );
   }
 }

--- a/cam_flutter/lib/udp_stream_receiver.dart
+++ b/cam_flutter/lib/udp_stream_receiver.dart
@@ -1,0 +1,65 @@
+import 'dart:async';
+import 'dart:io';
+import 'dart:typed_data';
+import 'package:flutter/foundation.dart';
+
+class UdpStreamReceiver extends ChangeNotifier {
+  final String camIp;
+  final int camPort;
+  final ValueNotifier<Uint8List?> frame = ValueNotifier(null);
+  RawDatagramSocket? _socket;
+  Timer? _keepAliveTimer;
+  final BytesBuilder _buffer = BytesBuilder();
+  bool _collecting = false;
+
+  UdpStreamReceiver({required this.camIp, this.camPort = 8080}) {
+    _bindSocket();
+  }
+
+  Future<void> _bindSocket() async {
+    _socket = await RawDatagramSocket.bind(InternetAddress.anyIPv4, 0);
+    _socket!.listen(_onEvent);
+    _keepAliveTimer =
+        Timer.periodic(const Duration(seconds: 1), (_) => _sendKeepAlive());
+  }
+
+  void _sendKeepAlive() {
+    _socket?.send(Uint8List.fromList([0x42, 0x76]), InternetAddress(camIp), camPort);
+  }
+
+  void _onEvent(RawSocketEvent event) {
+    if (event != RawSocketEvent.read) return;
+    final datagram = _socket!.receive();
+    if (datagram == null) return;
+    final data = datagram.data;
+    if (data.length <= 8) return;
+    final payload = data.sublist(8);
+    if (payload.length >= 2 && payload[0] == 0xff && payload[1] == 0xd8) {
+      _buffer.clear();
+      _buffer.add(payload);
+      _collecting = true;
+    } else if (_collecting) {
+      _buffer.add(payload);
+    }
+    if (_collecting && _endsWithEoi(payload)) {
+      frame.value = _buffer.takeBytes();
+      _collecting = false;
+      notifyListeners();
+    }
+  }
+
+  bool _endsWithEoi(Uint8List data) {
+    for (var i = 0; i < data.length - 1; i++) {
+      if (data[i] == 0xff && data[i + 1] == 0xd9) return true;
+    }
+    return false;
+  }
+
+  @override
+  void dispose() {
+    _keepAliveTimer?.cancel();
+    _socket?.close();
+    frame.dispose();
+    super.dispose();
+  }
+}


### PR DESCRIPTION
## Summary
- add UDP camera stream receiver with ChangeNotifier
- show frames via a provider and ValueListenableBuilder
- use ephemeral UDP port and keepalive to port 8080

## Testing
- `dart format -o none --set-exit-if-changed cam_flutter/lib/main.dart cam_flutter/lib/udp_stream_receiver.dart` *(fails: `dart` not found)*
- `flutter analyze` *(fails: `flutter` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68484acfbcc88326995a630c7fd3ac44