### PR TITLE
Add Flutter frame recording with ffmpeg

### DIFF
--- a/cam_flutter/lib/main.dart
+++ b/cam_flutter/lib/main.dart
@@ -1,6 +1,8 @@
-import 'dart:convert';
 import 'dart:typed_data';
+import 'dart:io';
 import 'package:flutter/material.dart';
+import 'package:path_provider/path_provider.dart';
+import 'package:ffmpeg_kit_flutter/ffmpeg_kit.dart';
 import 'package:web_socket_channel/web_socket_channel.dart';
 
 void main() {
@@ -17,15 +19,55 @@ class CamApp extends StatefulWidget {
 class _CamAppState extends State<CamApp> {
   final _channel = WebSocketChannel.connect(Uri.parse('ws://localhost:8081'));
   Uint8List? _frame;
+  bool _recording = false;
+  final List<Uint8List> _buffer = [];
+  Directory? _storeDir;
 
   @override
   void initState() {
     super.initState();
+    _initStorage();
     _channel.stream.listen((data) {
       setState(() {
         _frame = data as Uint8List;
+        if (_recording) {
+          _buffer.add(Uint8List.fromList(_frame!));
+        }
       });
     });
+  }
+
+  Future<void> _initStorage() async {
+    _storeDir = await getApplicationDocumentsDirectory();
+  }
+
+  Future<void> _toggleRecord() async {
+    if (!_recording) {
+      setState(() {
+        _recording = true;
+        _buffer.clear();
+      });
+    } else {
+      setState(() {
+        _recording = false;
+      });
+      await _saveRecording();
+    }
+  }
+
+  Future<void> _saveRecording() async {
+    if (_storeDir == null || _buffer.isEmpty) return;
+    final dir = await Directory(
+            '${_storeDir!.path}/${DateTime.now().millisecondsSinceEpoch}')
+        .create();
+    for (var i = 0; i < _buffer.length; i++) {
+      final file = File('${dir.path}/frame_${i.toString().padLeft(6, '0')}.jpg');
+      await file.writeAsBytes(_buffer[i]);
+    }
+    final outPath = '${dir.path}/output.mp4';
+    final cmd =
+        "-y -framerate 30 -i ${dir.path}/frame_%06d.jpg -c:v mpeg4 $outPath";
+    await FFmpegKit.execute(cmd);
   }
 
   @override
@@ -37,6 +79,10 @@ class _CamAppState extends State<CamApp> {
           child: _frame == null
               ? const Text('Waiting for stream...')
               : Image.memory(_frame!),
+        ),
+        floatingActionButton: FloatingActionButton(
+          onPressed: _toggleRecord,
+          child: Icon(_recording ? Icons.stop : Icons.fiber_manual_record),
         ),
       ),
     );

--- a/cam_flutter/pubspec.yaml
+++ b/cam_flutter/pubspec.yaml
@@ -11,3 +11,5 @@ dependencies:
   image: ^4.1.3
   provider: ^6.1.2
   web_socket_channel: ^2.4.0
+  ffmpeg_kit_flutter: ^5.1.0
+  path_provider: ^2.1.1


### PR DESCRIPTION
## Summary
- add `ffmpeg_kit_flutter` and `path_provider` dependencies
- record streamed JPEG frames in Flutter and encode them to MP4 using FFmpegKit
- expose recording toggle via floating action button

## Testing
- `python -m py_compile main.py webserver.py settings.py`
- *Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.*

------
https://chatgpt.com/codex/tasks/task_e_68484ae805108326b12c9d203e56bf20