### PR TITLE
Add log service for Flutter app

### DIFF
--- a/cam_flutter/lib/main.dart
+++ b/cam_flutter/lib/main.dart
@@ -2,8 +2,12 @@ import 'dart:convert';
 import 'dart:typed_data';
 import 'package:flutter/material.dart';
 import 'package:web_socket_channel/web_socket_channel.dart';
+import 'services/log_service.dart';
 
-void main() {
+Future<void> main() async {
+  WidgetsFlutterBinding.ensureInitialized();
+  await LogService.init();
+  LogService.instance.info('Application started');
   runApp(const CamApp());
 }
 
@@ -15,17 +19,27 @@ class CamApp extends StatefulWidget {
 }
 
 class _CamAppState extends State<CamApp> {
-  final _channel = WebSocketChannel.connect(Uri.parse('ws://localhost:8081'));
+  late final WebSocketChannel _channel;
   Uint8List? _frame;
 
   @override
   void initState() {
     super.initState();
-    _channel.stream.listen((data) {
-      setState(() {
-        _frame = data as Uint8List;
-      });
-    });
+    LogService.instance.info('Connecting to stream');
+    _channel = WebSocketChannel.connect(Uri.parse('ws://localhost:8081'));
+    _channel.stream.listen(
+      (data) {
+        setState(() {
+          _frame = data as Uint8List;
+        });
+      },
+      onError: (error) {
+        LogService.instance.error('WebSocket error: $error');
+      },
+      onDone: () {
+        LogService.instance.info('WebSocket closed');
+      },
+    );
   }
 
   @override
@@ -44,6 +58,7 @@ class _CamAppState extends State<CamApp> {
 
   @override
   void dispose() {
+    LogService.instance.info('Disposing app');
     _channel.sink.close();
     super.dispose();
   }

--- a/cam_flutter/lib/services/log_service.dart
+++ b/cam_flutter/lib/services/log_service.dart
@@ -1,0 +1,34 @@
+import 'dart:io';
+import 'package:path_provider/path_provider.dart';
+
+/// A simple singleton log service writing entries to a file and console.
+class LogService {
+  LogService._internal();
+
+  static final LogService instance = LogService._internal();
+
+  late final File _logFile;
+
+  /// Initializes the log file inside the application's document directory.
+  static Future<void> init() async {
+    final dir = await getApplicationDocumentsDirectory();
+    instance._logFile = File('${dir.path}/app.log');
+    if (!await instance._logFile.exists()) {
+      await instance._logFile.create(recursive: true);
+    }
+  }
+
+  /// Writes an info level entry.
+  void info(String msg) => _write('INFO', msg);
+
+  /// Writes an error level entry.
+  void error(String msg) => _write('ERROR', msg);
+
+  void _write(String level, String msg) {
+    final entry = '${DateTime.now().toIso8601String()} [$level] $msg';
+    // Print to console for quick feedback.
+    // Also append to the log file for persistence.
+    print(entry);
+    _logFile.writeAsStringSync('$entry\n', mode: FileMode.append);
+  }
+}

--- a/cam_flutter/pubspec.yaml
+++ b/cam_flutter/pubspec.yaml
@@ -11,3 +11,4 @@ dependencies:
   image: ^4.1.3
   provider: ^6.1.2
   web_socket_channel: ^2.4.0
+  path_provider: ^2.1.5


### PR DESCRIPTION
## Summary
- add a `LogService` that writes to console and an application log file
- initialise the log service and log app lifecycle events
- integrate logging with WebSocket status
- pull in `path_provider` dependency to locate log directory

## Testing
- `apt-get install -y dart` *(fails: package not found)*
- `flutter pub get` *(fails: command not found)*
- `python3 -m py_compile main.py`

------
https://chatgpt.com/codex/tasks/task_e_68484aff847c8326bf55d91181f9d3e0